### PR TITLE
Add program-specific DNS switching

### DIFF
--- a/AutoDNS/AutoDNS.csproj
+++ b/AutoDNS/AutoDNS.csproj
@@ -8,4 +8,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <None Update="programs.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/AutoDNS/ProgramDnsMonitor.cs
+++ b/AutoDNS/ProgramDnsMonitor.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AutoDNS
+{
+    public class ProgramDnsRule
+    {
+        public string ProgramPath { get; set; } = string.Empty;
+        public string Profile { get; set; } = string.Empty;
+    }
+
+    public sealed class ProgramDnsMonitor : IDisposable
+    {
+        private readonly MainForm form;
+        private readonly List<ProgramDnsRule> rules;
+        private readonly Timer timer;
+        private DnsProfile? currentProfile;
+
+        public ProgramDnsMonitor(MainForm form)
+        {
+            this.form = form;
+            rules = LoadRules();
+            timer = new Timer(CheckRules, null, 0, 5000);
+        }
+
+        private static List<ProgramDnsRule> LoadRules()
+        {
+            try
+            {
+                string path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "programs.json");
+                if (!File.Exists(path)) return new List<ProgramDnsRule>();
+                var json = File.ReadAllText(path);
+                return JsonSerializer.Deserialize<List<ProgramDnsRule>>(json) ?? new List<ProgramDnsRule>();
+            }
+            catch
+            {
+                return new List<ProgramDnsRule>();
+            }
+        }
+
+        private void CheckRules(object? state)
+        {
+            foreach (var rule in rules)
+            {
+                if (IsRunning(rule.ProgramPath))
+                {
+                    var profile = form.ProfileByName(rule.Profile);
+                    if (profile != null && currentProfile != profile)
+                    {
+                        form.BeginInvoke(new Func<Task>(async () => await form.ApplyProfileAsync(profile, true)));
+                        currentProfile = profile;
+                    }
+                    return;
+                }
+            }
+
+            if (currentProfile != form.AdGuard)
+            {
+                form.BeginInvoke(new Func<Task>(async () => await form.ApplyProfileAsync(form.AdGuard, true)));
+                currentProfile = form.AdGuard;
+            }
+        }
+
+        private static bool IsRunning(string fullPath)
+        {
+            if (string.IsNullOrWhiteSpace(fullPath)) return false;
+            string normalized = Path.GetFullPath(fullPath);
+            foreach (var p in Process.GetProcesses())
+            {
+                try
+                {
+                    var path = p.MainModule?.FileName;
+                    if (path != null && string.Equals(path, normalized, StringComparison.OrdinalIgnoreCase))
+                        return true;
+                }
+                catch
+                {
+                    // ignore processes we cannot access
+                }
+            }
+            return false;
+        }
+
+        public void Dispose()
+        {
+            timer.Dispose();
+        }
+    }
+}
+

--- a/AutoDNS/programs.json
+++ b/AutoDNS/programs.json
@@ -1,0 +1,7 @@
+[
+  {
+    "ProgramPath": "C:\\Program Files\\Example\\app.exe",
+    "Profile": "Cloudflare"
+  }
+]
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # AutoDNS
+
+This project allows switching DNS settings for selected network interfaces.  
+It now supports automatic DNS switching based on running programs.
+
+## Program-specific DNS
+
+Edit the `programs.json` file to map program executables to DNS profiles:
+
+```
+[
+  {
+    "ProgramPath": "C:\\Path\\To\\app.exe",
+    "Profile": "Cloudflare"
+  }
+]
+```
+
+When a listed program is detected running, AutoDNS applies the specified DNS.  
+Once all monitored programs exit, it automatically switches back to AdGuard DNS.


### PR DESCRIPTION
## Summary
- monitor configured programs and switch DNS when they run
- expose helper APIs and config to apply DNS profiles automatically
- document new `programs.json` config for per-program DNS

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab26e75fe08331bad15e35361526f4